### PR TITLE
fix: avoid strerror_r exit

### DIFF
--- a/src/butil/errno.cpp
+++ b/src/butil/errno.cpp
@@ -54,16 +54,19 @@ int DescribeCustomizedErrno(
     } else {
 #if defined(OS_MACOSX)
         const int rc = strerror_r(error_code, tls_error_buf, ERROR_BUFSIZE);
-        if (rc != EINVAL)
+        if (rc != EINVAL) {
+            fprintf(stderr, "Fail to define %s(%d) which is already defined as `%s', abort.",
+                    error_name, error_code, desc);
+            _exit(1);
+        }
 #else
         desc = strerror_r(error_code, tls_error_buf, ERROR_BUFSIZE);
-        if (desc != tls_error_buf)
-#endif
-        {
+        if (desc != tls_error_buf) {
           fprintf(stderr,
                   "%d is defined as `%s', probably is the system errno.\n",
                   error_code, desc);
         }
+#endif
     }
     errno_desc[error_code - ERRNO_BEGIN] = description;
     return 0;  // must

--- a/src/butil/errno.cpp
+++ b/src/butil/errno.cpp
@@ -60,9 +60,9 @@ int DescribeCustomizedErrno(
         if (desc != tls_error_buf)
 #endif
         {
-            fprintf(stderr, "Fail to define %s(%d) which is already defined as `%s', abort.",
-                    error_name, error_code, desc);
-            // _exit(1);
+          fprintf(stderr,
+                  "%d is defined as `%s', probably is the system errno.\n",
+                  error_code, desc);
         }
     }
     errno_desc[error_code - ERRNO_BEGIN] = description;

--- a/src/butil/errno.cpp
+++ b/src/butil/errno.cpp
@@ -57,12 +57,12 @@ int DescribeCustomizedErrno(
         if (rc != EINVAL)
 #else
         desc = strerror_r(error_code, tls_error_buf, ERROR_BUFSIZE);
-        if (desc && strncmp(desc, "Unknown error", 13) != 0)
+        if (desc != tls_error_buf)
 #endif
         {
             fprintf(stderr, "Fail to define %s(%d) which is already defined as `%s', abort.",
                     error_name, error_code, desc);
-            _exit(1);
+            // _exit(1);
         }
     }
     errno_desc[error_code - ERRNO_BEGIN] = description;


### PR DESCRIPTION
If the returned `desc` != the param `tls_error_buf `,  it usually means that error is the system error(already defined, static).
Not-defined errors return the `buf` "Unknown error nnn" or "未知的错误 nnn",  and `desc==buf`.(cannot guarantee, so avoid exit too)